### PR TITLE
feat: use NodeNext module resolution with explicit .js extensions

### DIFF
--- a/src/box3.ts
+++ b/src/box3.ts
@@ -1,6 +1,6 @@
-import type { Box3, Mat4, Plane3, Sphere, Vec3 } from './types';
-import * as common from './common';
-import * as vec3 from './vec3';
+import type { Box3, Mat4, Plane3, Sphere, Vec3 } from './types.js';
+import * as common from './common.js';
+import * as vec3 from './vec3.js';
 
 /**
  * Create a new empty Box3 with "min" set to positive infinity and "max" set to negative infinity

--- a/src/circle.ts
+++ b/src/circle.ts
@@ -1,4 +1,4 @@
-import type { Circle } from './types';
+import type { Circle } from './types.js';
 
 export function create(): Circle {
     return { center: [0, 0], radius: 0 };

--- a/src/circumcircle.ts
+++ b/src/circumcircle.ts
@@ -1,6 +1,6 @@
-import { EPSILON } from './common';
-import type { Circle, Vec2 } from './types';
-import * as vec2 from './vec2';
+import { EPSILON } from './common.js';
+import type { Circle, Vec2 } from './types.js';
+import * as vec2 from './vec2.js';
 
 const _circumcircleV1 = /*@__PURE__*/ vec2.create();
 const _circumcircleV2 = /*@__PURE__*/ vec2.create();

--- a/src/euler.ts
+++ b/src/euler.ts
@@ -1,7 +1,7 @@
-import { clamp, EPSILON } from './common';
-import * as mat4 from './mat4';
-import * as quat from './quat';
-import type { Euler, EulerOrder, Mat4, Quat } from './types';
+import { clamp, EPSILON } from './common.js';
+import * as mat4 from './mat4.js';
+import * as quat from './quat.js';
+import type { Euler, EulerOrder, Mat4, Quat } from './types.js';
 
 /**
  * Creates a new Euler with default values (0, 0, 0, 'xyz').

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,40 +1,40 @@
 /** biome-ignore-all assist/source/organizeImports: ordering */
 
-export * from './types';
+export * from './types.js';
 
-export * as vec2 from './vec2';
-export * as vec3 from './vec3';
-export * as vec4 from './vec4';
+export * as vec2 from './vec2.js';
+export * as vec3 from './vec3.js';
+export * as vec4 from './vec4.js';
 
-export * as euler from './euler';
+export * as euler from './euler.js';
 
-export * as quat from './quat';
-export * as quat2 from './quat2';
+export * as quat from './quat.js';
+export * as quat2 from './quat2.js';
 
-export * as mat2 from './mat2';
-export * as mat2d from './mat2d';
-export * as mat3 from './mat3';
-export * as mat4 from './mat4';
+export * as mat2 from './mat2.js';
+export * as mat2d from './mat2d.js';
+export * as mat3 from './mat3.js';
+export * as mat4 from './mat4.js';
 
-export * as circle from './circle';
-export * as segment2 from './segment2';
+export * as circle from './circle.js';
+export * as segment2 from './segment2.js';
 
-export * as box3 from './box3';
-export * as obb3 from './obb3';
-export * as plane3 from './plane3';
-export * as sphere from './sphere';
-export * as triangle3 from './triangle3';
+export * as box3 from './box3.js';
+export * as obb3 from './obb3.js';
+export * as plane3 from './plane3.js';
+export * as sphere from './sphere.js';
+export * as triangle3 from './triangle3.js';
 
-export * as raycast3 from './raycast3';
+export * as raycast3 from './raycast3.js';
 
-export * from './quickhull3';
-export * from './quickhull2';
+export * from './quickhull3.js';
+export * from './quickhull2.js';
 
-export * from "./circumcircle";
+export * from "./circumcircle.js";
 
-export * as easing from './easing';
+export * as easing from './easing.js';
 
-export * from './noise';
-export * from './random';
+export * from './noise.js';
+export * from './random.js';
 
-export * from './common';
+export * from './common.js';

--- a/src/mat2.ts
+++ b/src/mat2.ts
@@ -1,5 +1,5 @@
-import * as common from './common';
-import type { Mat2, Vec2 } from './types';
+import * as common from './common.js';
+import type { Mat2, Vec2 } from './types.js';
 
 /**
  * Creates a new identity mat2

--- a/src/mat2d.ts
+++ b/src/mat2d.ts
@@ -1,5 +1,5 @@
-import * as common from './common';
-import type { Mat2d, Vec2 } from './types';
+import * as common from './common.js';
+import type { Mat2d, Vec2 } from './types.js';
 
 /**
  * Creates a new identity mat2d

--- a/src/mat3.ts
+++ b/src/mat3.ts
@@ -1,5 +1,5 @@
-import * as common from './common';
-import type { Mat2d, Mat3, Mat4, Quat, Vec2 } from './types';
+import * as common from './common.js';
+import type { Mat2d, Mat3, Mat4, Quat, Vec2 } from './types.js';
 
 /**
  * Creates a new identity mat3

--- a/src/mat4.ts
+++ b/src/mat4.ts
@@ -1,5 +1,5 @@
-import * as common from './common';
-import type { Mat4, Quat, Quat2, Vec3 } from './types';
+import * as common from './common.js';
+import type { Mat4, Quat, Quat2, Vec3 } from './types.js';
 
 /**
  * Creates a new identity mat4

--- a/src/noise.ts
+++ b/src/noise.ts
@@ -1,5 +1,5 @@
-import { fade, lerp } from './common';
-import type { Vec3 } from './types';
+import { fade, lerp } from './common.js';
+import type { Vec3 } from './types.js';
 
 // adapted from maath:
 // https://github.com/pmndrs/maath/blob/main/packages/maath/src/random/noise.ts

--- a/src/obb3.ts
+++ b/src/obb3.ts
@@ -1,7 +1,7 @@
-import * as mat3 from './mat3';
-import * as mat4 from './mat4';
-import type { Box3, Mat3, Mat4, OBB3, Quat, Vec3 } from './types';
-import * as vec3 from './vec3';
+import * as mat3 from './mat3.js';
+import * as mat4 from './mat4.js';
+import type { Box3, Mat3, Mat4, OBB3, Quat, Vec3 } from './types.js';
+import * as vec3 from './vec3.js';
 
 export function create(): OBB3 {
     return { center: [0, 0, 0], halfExtents: [1, 1, 1], rotation: mat3.create() };

--- a/src/plane3.ts
+++ b/src/plane3.ts
@@ -1,5 +1,5 @@
-import type { Mat4, Plane3, Sphere, Vec3 } from './types';
-import * as vec3 from './vec3';
+import type { Mat4, Plane3, Sphere, Vec3 } from './types.js';
+import * as vec3 from './vec3.js';
 
 /**
  * Creates a new plane with normal (0, 1, 0) and constant 0

--- a/src/quat.ts
+++ b/src/quat.ts
@@ -1,8 +1,8 @@
-import * as common from './common';
-import * as mat3 from './mat3';
-import type { Euler, EulerOrder, Mat3, Mat4, Quat, Vec3 } from './types';
-import * as vec3 from './vec3';
-import * as vec4 from './vec4';
+import * as common from './common.js';
+import * as mat3 from './mat3.js';
+import type { Euler, EulerOrder, Mat3, Mat4, Quat, Vec3 } from './types.js';
+import * as vec3 from './vec3.js';
+import * as vec4 from './vec4.js';
 
 /**
  * Creates a new identity quat

--- a/src/quat2.ts
+++ b/src/quat2.ts
@@ -1,7 +1,7 @@
-import * as common from './common';
-import * as mat4 from './mat4';
-import * as quat from './quat';
-import type { Mat4, Quat, Quat2, Vec3 } from './types';
+import * as common from './common.js';
+import * as mat4 from './mat4.js';
+import * as quat from './quat.js';
+import type { Mat4, Quat, Quat2, Vec3 } from './types.js';
 
 /**
  * Creates a new identity dual quat

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,4 +1,4 @@
-import type { Quat, Vec2, Vec3, Vec4 } from './types';
+import type { Quat, Vec2, Vec3, Vec4 } from './types.js';
 
 /**
  * Creates a Mulberry32 seeded pseudo-random number generator.

--- a/src/raycast3.ts
+++ b/src/raycast3.ts
@@ -1,5 +1,5 @@
-import type { Box3, Raycast3, Vec3 } from './types';
-import * as vec3 from './vec3';
+import type { Box3, Raycast3, Vec3 } from './types.js';
+import * as vec3 from './vec3.js';
 
 /**
  * Creates a new Raycast3 with default values (origin at (0,0,0), direction (0,0,0), length 1.

--- a/src/segment2.ts
+++ b/src/segment2.ts
@@ -1,4 +1,4 @@
-import type { Vec2 } from './types';
+import type { Vec2 } from './types.js';
 
 /**
  * Calculates the closest point on a line segment to a given point

--- a/src/sphere.ts
+++ b/src/sphere.ts
@@ -1,4 +1,4 @@
-import type { Sphere } from "./types";
+import type { Sphere } from "./types.js";
 
 /**
  * Creates a new sphere with a default center 0,0,0 and radius 1

--- a/src/triangle3.ts
+++ b/src/triangle3.ts
@@ -1,4 +1,4 @@
-import type { Box3, Vec3 } from './types';
+import type { Box3, Vec3 } from './types.js';
 
 /**
  * Computes the axis-aligned bounding box of a triangle defined by three vertices.

--- a/src/vec2.ts
+++ b/src/vec2.ts
@@ -1,5 +1,5 @@
-import * as common from './common';
-import type { Mat2, Mat2d, Mat3, Mat4, Vec2, Vec3 } from './types';
+import * as common from './common.js';
+import type { Mat2, Mat2d, Mat3, Mat4, Vec2, Vec3 } from './types.js';
 
 /**
  * Creates a new, empty vec2

--- a/src/vec3.ts
+++ b/src/vec3.ts
@@ -1,5 +1,5 @@
-import * as common from './common';
-import type { Mat3, Mat4, MutableArrayLike, Quat, Vec3 } from './types';
+import * as common from './common.js';
+import type { Mat3, Mat4, MutableArrayLike, Quat, Vec3 } from './types.js';
 
 /**
  * Creates a new, empty vec3

--- a/src/vec4.ts
+++ b/src/vec4.ts
@@ -1,5 +1,5 @@
-import * as common from './common';
-import type { Mat4, Quat, Vec4 } from './types';
+import * as common from './common.js';
+import type { Mat4, Quat, Vec4 } from './types.js';
 
 /**
  * Creates a new, empty vec4

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,9 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "module": "ES2022",
+    "module": "NodeNext",
     "lib": ["ES2022", "DOM"],
-    "moduleResolution": "bundler",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tst/box3.test.ts
+++ b/tst/box3.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Box3, Mat4, Plane3, Sphere, Vec3 } from '../dist';
-import { box3 } from '../dist';
+import type { Box3, Mat4, Plane3, Sphere, Vec3 } from '../dist/index.js';
+import { box3 } from '../dist/index.js';
 
 describe('box3', () => {
     describe('create', () => {

--- a/tst/circumcircle.test.ts
+++ b/tst/circumcircle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type Circle, circumcircle, type Vec2 } from '../dist';
+import { type Circle, circumcircle, type Vec2 } from '../dist/index.js';
 
 describe('circumcircle', () => {
     it('calculates circumcircle for a simple triangle', () => {

--- a/tst/euler.test.ts
+++ b/tst/euler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Euler, EulerOrder } from '../dist';
-import { euler, mat4, quat } from '../dist';
+import type { Euler, EulerOrder } from '../dist/index.js';
+import { euler, mat4, quat } from '../dist/index.js';
 
 describe('euler', () => {
     describe('create', () => {

--- a/tst/mat2.test.ts
+++ b/tst/mat2.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Mat2, Vec2 } from '../dist';
-import { mat2 } from '../dist';
+import type { Mat2, Vec2 } from '../dist/index.js';
+import { mat2 } from '../dist/index.js';
 
 describe('mat2', () => {
     describe('create', () => {

--- a/tst/mat2d.test.ts
+++ b/tst/mat2d.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Mat2d, Vec2 } from '../dist';
-import { mat2d } from '../dist';
+import type { Mat2d, Vec2 } from '../dist/index.js';
+import { mat2d } from '../dist/index.js';
 
 describe('mat2d', () => {
     describe('create', () => {

--- a/tst/mat3.test.ts
+++ b/tst/mat3.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Mat3, Mat4, Mat2d, Vec2 } from '../dist';
-import { mat3, mat4, quat } from '../dist';
+import type { Mat3, Mat4, Mat2d, Vec2 } from '../dist/index.js';
+import { mat3, mat4, quat } from '../dist/index.js';
 
 describe('mat3', () => {
     describe('create', () => {

--- a/tst/mat4.test.ts
+++ b/tst/mat4.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Mat4, Vec3 } from '../dist';
-import { mat4, quat } from '../dist';
+import type { Mat4, Vec3 } from '../dist/index.js';
+import { mat4, quat } from '../dist/index.js';
 
 describe('mat4', () => {
     describe('create', () => {

--- a/tst/obb3.test.ts
+++ b/tst/obb3.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import * as box3 from '../src/box3';
-import * as euler from '../src/euler';
-import * as mat3 from '../src/mat3';
-import * as mat4 from '../src/mat4';
-import * as obb3 from '../src/obb3';
-import * as quat from '../src/quat';
-import * as vec3 from '../src/vec3';
+import * as box3 from '../src/box3.js';
+import * as euler from '../src/euler.js';
+import * as mat3 from '../src/mat3.js';
+import * as mat4 from '../src/mat4.js';
+import * as obb3 from '../src/obb3.js';
+import * as quat from '../src/quat.js';
+import * as vec3 from '../src/vec3.js';
 
 describe('obb3', () => {
     describe('setFromBox3', () => {

--- a/tst/quat.test.ts
+++ b/tst/quat.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Euler, Mat3, Quat, Vec3 } from '../dist';
-import { mat4, quat, vec3 } from '../dist';
+import type { Euler, Mat3, Quat, Vec3 } from '../dist/index.js';
+import { mat4, quat, vec3 } from '../dist/index.js';
 
 describe('quat', () => {
     describe('create', () => {

--- a/tst/quat2.test.ts
+++ b/tst/quat2.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Quat, Quat2, Vec3 } from '../dist';
-import { mat4, quat, quat2 } from '../dist';
+import type { Quat, Quat2, Vec3 } from '../dist/index.js';
+import { mat4, quat, quat2 } from '../dist/index.js';
 
 describe('quat2', () => {
     describe('create', () => {

--- a/tst/quickhull2.test.ts
+++ b/tst/quickhull2.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { quickhull2 } from '../dist';
+import { quickhull2 } from '../dist/index.js';
 
 describe('hull2', () => {
     describe('quickhull2', () => {

--- a/tst/quickhull3.test.ts
+++ b/tst/quickhull3.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { quickhull3 } from '../dist';
+import { quickhull3 } from '../dist/index.js';
 
 const EPS = 1e-6;
 

--- a/tst/raycast3.test.ts
+++ b/tst/raycast3.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Box3, Vec3, Raycast3 } from '../dist';
-import { raycast3, vec3 } from '../dist';
+import type { Box3, Vec3, Raycast3 } from '../dist/index.js';
+import { raycast3, vec3 } from '../dist/index.js';
 
 describe('raycast3', () => {
     describe('create', () => {

--- a/tst/segment2.test.ts
+++ b/tst/segment2.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { segment2, type Vec2 } from '../dist';
+import { segment2, type Vec2 } from '../dist/index.js';
 
 describe('segment2.closestPoint', () => {
     it('returns the closest point for a point inside the segment', () => {

--- a/tst/vec2.test.ts
+++ b/tst/vec2.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { type Vec2, type Vec3, vec2 } from '../dist';
+import { type Vec2, type Vec3, vec2 } from '../dist/index.js';
 
 describe('vec2', () => {
     let a: Vec2;

--- a/tst/vec3.test.ts
+++ b/tst/vec3.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { type Vec3, vec3 } from '../dist';
+import { type Vec3, vec3 } from '../dist/index.js';
 
 describe('vec3', () => {
     let a: Vec3;

--- a/tst/vec4.test.ts
+++ b/tst/vec4.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { type Vec4, vec4 } from '../dist';
+import { type Vec4, vec4 } from '../dist/index.js';
 
 describe('vec4', () => {
     let a: Vec4;


### PR DESCRIPTION
Adds .js extensions to all relative imports in src and tst (and ../dist/index.js for tst imports of the built barrel). Flips tsconfig module + moduleResolution to NodeNext.

Lets tsc emit .d.ts files that resolve cleanly under consumer projects using moduleResolution: NodeNext, without any post-build rewriting.