### PR TITLE
Emit .d.ts with explicit .js extensions for ESM NodeNext

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,7 +1,34 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import filesize from 'rollup-plugin-filesize';
+
+const fixDtsExtensions = () => ({
+  name: 'fix-dts-extensions',
+  writeBundle() {
+    const root = path.resolve('dist');
+    if (!fs.existsSync(root)) return;
+    const walk = (dir) =>
+      fs.readdirSync(dir, { withFileTypes: true }).flatMap((d) => {
+        const p = path.join(dir, d.name);
+        return d.isDirectory() ? walk(p) : [p];
+      });
+    for (const file of walk(root).filter((f) => f.endsWith('.d.ts'))) {
+      const dir = path.dirname(file);
+      const original = fs.readFileSync(file, 'utf8');
+      const fixed = original.replace(
+        /(from\s+['"])(\.[^'"]+)(['"])/g,
+        (_, pre, spec, post) => {
+          if (fs.existsSync(path.join(dir, `${spec}.d.ts`))) return `${pre}${spec}.js${post}`;
+          if (fs.existsSync(path.join(dir, spec, 'index.d.ts'))) return `${pre}${spec}/index.js${post}`;
+          return `${pre}${spec}${post}`;
+        },
+      );
+      if (fixed !== original) fs.writeFileSync(file, fixed);
+    }
+  },
+});
 
 export default [
   {
@@ -22,6 +49,7 @@ export default [
         tsconfig: path.resolve(import.meta.dirname, './tsconfig.json'),
         emitDeclarationOnly: true,
       }),
+      fixDtsExtensions(),
       filesize(),
     ],
   },


### PR DESCRIPTION
ESM NodeNext requires explicit file extensions (`.js`) in imports inside emitted `dist/**/*.d.ts`.

This PR adds a small rollup plugin in `writeBundle()` that adds `.js` to imports` in `dist/**/*.d.ts`.

---

TS source files are untouched, though we could remove the need for this rollup `writeBundle()` plugin if the TS source imports were updated to include file extensions, which seems to be the standard going forward:

Sample ESM module syntax from [TypeScript docs](https://www.typescriptlang.org/docs/handbook/modules/reference.html#module-syntax):
```ts
// @Filename: main.ts
import { f, type SomeInterface } from "./module.js";
import type { SomeType } from "./module.js";
```

The previous PR (https://github.com/isaac-mason/mathcat/pull/3) did these TS source updates. Though I'm happy to go with the approach you find to be the least friction.

---

Related minimal repro: https://github.com/regnaio/esm-extension

---

I'm curious to hear your thoughts on this, and thank you for your time and help, @isaac-mason !
